### PR TITLE
fix github issue #122 - correct hemisphere on C2PA GPS longitude/latitude

### DIFF
--- a/android-libproofmode/src/main/java/org/witness/proofmode/c2pa/C2PAManager.kt
+++ b/android-libproofmode/src/main/java/org/witness/proofmode/c2pa/C2PAManager.kt
@@ -78,6 +78,8 @@ import java.util.StringTokenizer
 import java.util.TimeZone
 import javax.crypto.Cipher
 import javax.security.auth.x500.X500Principal
+import kotlin.math.abs
+import kotlin.math.floor
 
 enum class ValidationState {
     TRUSTED,
@@ -98,6 +100,26 @@ class C2PAManager(private val context: Context, private val preferencesManager: 
 
         private const val TSA_DEFAULT = BuildConfig.TSA_SERVER
 
+        /**
+         * Formats a signed decimal-degrees coordinate as an XMP GPSCoordinate string
+         * ("D,M.mmmmmmH"), which is what the exif:GPSLatitude / exif:GPSLongitude
+         * fields expect in a C2PA/XMP metadata assertion. Unlike the binary EXIF IFD
+         * (which pairs a rational value with a separate GPSLatitudeRef/GPSLongitudeRef
+         * tag), XMP has no ref tag: the hemisphere has to be folded into the string
+         * itself, and the numeric part must be unsigned. Writing the raw signed
+         * double here (e.g. "-6.1483...") drops that hemisphere letter entirely, so
+         * readers fall back to a default ref and can flip western longitudes/southern
+         * latitudes to the wrong hemisphere (github issue #122).
+         */
+        internal fun toXmpGpsCoordinate(decimalDegrees: Double, positiveRef: String, negativeRef: String): String {
+            val ref = if (decimalDegrees < 0) negativeRef else positiveRef
+            val absDegrees = abs(decimalDegrees)
+            val degrees = floor(absDegrees).toInt()
+            val minutes = (absDegrees - degrees) * 60.0
+            // Locale.US keeps the decimal point a "." regardless of device locale -
+            // a comma here would collide with the "D,M" separator and corrupt the field.
+            return "$degrees,${String.format(Locale.US, "%.6f", minutes)}$ref"
+        }
     }
 
     private var trustAnchors: String? = null
@@ -1086,8 +1108,8 @@ class C2PAManager(private val context: Context, private val preferencesManager: 
 
                     location?.let {
                         put ("exif:GPSVersionID", "2.2.0.0")
-                        put("exif:GPSLatitude", it.latitude.toString())
-                        put("exif:GPSLongitude", it.longitude.toString())
+                        put("exif:GPSLatitude", toXmpGpsCoordinate(it.latitude, "N", "S"))
+                        put("exif:GPSLongitude", toXmpGpsCoordinate(it.longitude, "E", "W"))
                         put("exif:GPSAltitude", it.altitude.toString())
                         put ("exif:GPSHPositioningError", it.accuracy.toString())
                         put ("exif:GPSSpeed", it.speed.toString())

--- a/android-libproofmode/src/test/java/org/witness/proofmode/c2pa/C2PAManagerGpsCoordinateTest.kt
+++ b/android-libproofmode/src/test/java/org/witness/proofmode/c2pa/C2PAManagerGpsCoordinateTest.kt
@@ -1,0 +1,60 @@
+package org.witness.proofmode.c2pa
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Regression coverage for github issue #122: a photo taken west of the prime
+ * meridian (a negative longitude) ended up with its EXIF/C2PA longitude
+ * reported in the eastern hemisphere. The exif:GPSLatitude / exif:GPSLongitude
+ * fields in the C2PA metadata assertion are XMP GPSCoordinate strings, not raw
+ * signed doubles, so [C2PAManager.toXmpGpsCoordinate] has to strip the sign and
+ * fold the hemisphere into the string itself.
+ */
+class C2PAManagerGpsCoordinateTest {
+
+    @Test
+    fun negativeLongitudeIsReportedAsWest() {
+        // 6 degrees, 8 minutes, 54.154 seconds west, from the issue report.
+        val decimalDegrees = -(6.0 + 8.0 / 60.0 + 54.154 / 3600.0)
+
+        val result = C2PAManager.toXmpGpsCoordinate(decimalDegrees, "E", "W")
+
+        assertTrue("expected a West reference, got: $result", result.endsWith("W"))
+        assertTrue("expected no leading minus sign, got: $result", !result.startsWith("-"))
+        assertEquals("6,8.902567W", result)
+    }
+
+    @Test
+    fun positiveLongitudeIsReportedAsEast() {
+        val result = C2PAManager.toXmpGpsCoordinate(6.148376, "E", "W")
+
+        assertTrue("expected an East reference, got: $result", result.endsWith("E"))
+        assertEquals("6,8.902560E", result)
+    }
+
+    @Test
+    fun negativeLatitudeIsReportedAsSouth() {
+        val result = C2PAManager.toXmpGpsCoordinate(-33.865143, "N", "S")
+
+        assertTrue("expected a South reference, got: $result", result.endsWith("S"))
+        assertTrue("expected no leading minus sign, got: $result", !result.startsWith("-"))
+    }
+
+    @Test
+    fun positiveLatitudeIsReportedAsNorth() {
+        val result = C2PAManager.toXmpGpsCoordinate(33.865143, "N", "S")
+
+        assertTrue("expected a North reference, got: $result", result.endsWith("N"))
+    }
+
+    @Test
+    fun zeroDegreesDefaultsToThePositiveRef() {
+        // The prime meridian / equator aren't negative zero, so this should
+        // resolve to the positive hemisphere letter rather than throw or flip.
+        val result = C2PAManager.toXmpGpsCoordinate(0.0, "E", "W")
+
+        assertTrue(result.endsWith("E"))
+    }
+}


### PR DESCRIPTION
Related to #122 - fixes the coordinate-format problem that's still on main after n8fr8's 3400860 (2026-06-26) fixed the missing-GPS symptom from that thread.

The reporter was on 2.6.0-RC-2, which is before `C2PAManager.kt` existed. That report traces to the old `GPSTracker.getLatitudeAsDMS()`/`getLongitudeAsDMS()` (still in the tree under `org.witness.proofmode.c2pa`, but no longer called from anywhere on main) - both hardcoded a `" N"`/`" W"` suffix regardless of the actual sign of the coordinate.

What's still live on main is a different instance of the same underlying problem: `exif:GPSLatitude`/`exif:GPSLongitude` in the C2PA metadata assertion get written as a raw signed decimal (`it.longitude.toString()`). Binary EXIF pairs an unsigned rational with a separate `GPSLatitudeRef`/`GPSLongitudeRef` tag, but this is an XMP-style assertion and XMP has no ref tag - the hemisphere has to be encoded directly in the coordinate string as `D,M.mmmmmmH` (e.g. `6,8.902567W`). A plain signed double drops the hemisphere letter, so exiftool/the C2PA verify tool has nothing to go on for which side of the meridian or equator the point is on.

The fix adds `toXmpGpsCoordinate()`, which converts a signed decimal-degree value into that `D,M.mmmmmmH` form and picks the hemisphere letter from the sign, then uses it for both latitude and longitude. Formatting uses `Locale.US` so a comma-decimal device locale can't turn `6,8.902567W` into `6,8,902567W` and corrupt the field.

I couldn't run the Android instrumentation suite here (no device/emulator, no local JDK/Android SDK in this environment), but I added a JVM unit test (`C2PAManagerGpsCoordinateTest`) that exercises `toXmpGpsCoordinate()` directly - the negative-longitude case from the issue (west stays west, no leading minus sign) and the equivalent latitude cases. It lives in `src/test`, same pattern as `ClaimBindingConformanceTest`, so it runs on the JVM without a device. I checked the expected DMS values by hand before writing the assertions, but since this repo doesn't run test CI, it'd help if someone ran `gradlew :android-libproofmode:testDebugUnitTest` locally to confirm.
