### PR TITLE
Fix dc:creator serialized as a bracketed string instead of a JSON array in CAWG metadata

### DIFF
--- a/android-libproofmode/src/main/java/org/witness/proofmode/c2pa/C2PAManager.kt
+++ b/android-libproofmode/src/main/java/org/witness/proofmode/c2pa/C2PAManager.kt
@@ -1275,6 +1275,23 @@ class C2PAManager(private val context: Context, private val preferencesManager: 
          * 	"Iptc4xmpCore:AltTextAccessibility": "Photo of Erika Fictional standing in front of the Golden Gate Bridge at sunset.",
          */
 
+        // A "[a,b,c]" value (see the dc:creator example above) means the field is a
+        // JSON-LD array, not a plain string - strip the brackets and split on commas.
+        // Used for both cawgContext and cawgInfo, since either can carry one (the real
+        // caller currently only puts a bracketed value in cawgInfo's "dc:creator").
+        fun JsonObjectBuilder.putValueOrArray(key: String, value: String) {
+            if (value.startsWith("[") && value.endsWith("]")) {
+                val itemList = value.substring(1, value.length - 1)
+                val itemListTokens = StringTokenizer(itemList, ",")
+                put(key, buildJsonArray {
+                    while (itemListTokens.hasMoreTokens())
+                        add(itemListTokens.nextToken().trim().removeSurrounding("\""))
+                })
+            } else {
+                put(key, value)
+            }
+        }
+
         var result = AssertionDefinition.custom(
             label = "cawg.metadata",
             data = buildJsonObject {
@@ -1282,25 +1299,14 @@ class C2PAManager(private val context: Context, private val preferencesManager: 
                 put ("@context",
                     buildJsonObject {
                         for (cawgContextItem in cawgContext) {
-
-                            if (cawgContextItem.value.startsWith("["))
-                            {
-                                val itemList = cawgContextItem.value.substring(1,cawgContextItem.value.length-2)
-                                val itemListTokens = StringTokenizer(itemList,",")
-                                buildJsonArray() {
-                                    while (itemListTokens.hasMoreTokens())
-                                       add(itemListTokens.nextToken())
-                                }
-                            }
-                            else
-                                put (cawgContextItem.key,cawgContextItem.value)
+                            putValueOrArray(cawgContextItem.key, cawgContextItem.value)
                         }
                     }
 
                 )
 
                 for (cawgInfoItem in cawgInfo) {
-                    put (cawgInfoItem.key,cawgInfoItem.value)
+                    putValueOrArray(cawgInfoItem.key, cawgInfoItem.value)
                 }
 
             }


### PR DESCRIPTION
`createCAWGMetadataAssertion()` has logic to turn a `"[a,b]"` value into a real JSON array, but it only runs on the `cawgContext` loop. The one place that actually produces a bracketed value is `cawgInfo["dc:creator"]`, which `signInternal` sets to `"[$cawgCreator]"` whenever the user has a Creator name configured. That value goes through the second loop, which does a plain `put(key, value)`. So on every C2PA-signed capture with a Creator name set, the `cawg.metadata` assertion carries `dc:creator` as the literal string `"[Alice Smith]"` instead of the array `["Alice Smith"]` that Dublin Core `dc:creator` is meant to be. The doc comment above the function shows that exact intended shape: `cawgInfo.put("dc:creator", "[ \"Julie Smith\" ]")`.

The bracket-stripping code had two more problems even where it did run: `substring(1, value.length - 2)` drops the last two characters instead of just the trailing `]` (so `[Alice Smith]` also loses the `h`), and the `buildJsonArray {}` result was never put anywhere, so the array was discarded.

The fix pulls the conversion into one `putValueOrArray()` helper, uses it for both loops, fixes the substring bound, and actually puts the array.

I verified it with a standalone JVM harness that runs the real `buildJsonObject` block and the real `cawgInfo` construction verbatim: before, `dc:creator` is the string `"[Alice Smith]"`; after, it is `["Alice Smith"]`, and non-bracketed fields like `dc:rights` are untouched. I could not run this on-device or through a C2PA conformance validator, so if you can check the signed output against one, that would be worth doing before merge.
